### PR TITLE
Add `bool` to partial active patterns section, etc.

### DIFF
--- a/docs/fsharp-cheatsheet.md
+++ b/docs/fsharp-cheatsheet.md
@@ -895,7 +895,7 @@ A partial active pattern must return an `Option<'T>` or, as of [F# 9](https://le
 
 - `bool`
     ```fsharp
-    let (|CaseInsensitive|_|) (pattern: string) (value: string) =
+    let (|EqualsIgnoreCase|_|) (pattern: string) (value: string) =
         String.Equals(value, pattern, StringComparison.OrdinalIgnoreCase)
     ```
 

--- a/docs/fsharp-cheatsheet.md
+++ b/docs/fsharp-cheatsheet.md
@@ -877,9 +877,10 @@ match "yennefer@aretuza.org" with // output: "Email: yennefer@aretuza.org"
 
 *Partial active patterns* share the syntax of parameterized patterns, but their active recognizers accept only one argument.
 
-A partial active pattern must return an `Option<'T>` or, as of [F# 9](https://learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9#partial-active-patterns-can-return-bool-instead-of-unit-option), a `bool`.
+A partial active pattern typically returns an `Option<'T>`. However, as of [F# 9](https://learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9#partial-active-patterns-can-return-bool-instead-of-unit-option), where no value is being returned, and there is only one success case, you may return a `bool` instead.
 
 - `Option<T>`
+
     ```fsharp
     let (|DivisibleBy|_|) by n =
         if n % by = 0
@@ -894,6 +895,11 @@ A partial active pattern must return an `Option<'T>` or, as of [F# 9](https://le
     ```
 
 - `bool`
+
+    ```fsharp
+    let (|DivisibleBy|_|) by n = n % by = 0
+    ```
+
     ```fsharp
     let (|EqualsIgnoreCase|_|) (pattern: string) (value: string) =
         String.Equals(value, pattern, StringComparison.OrdinalIgnoreCase)

--- a/docs/fsharp-cheatsheet.md
+++ b/docs/fsharp-cheatsheet.md
@@ -216,7 +216,7 @@ The most common use is when you have a function that receives no parameters, but
 let getCurrentDateTime = DateTime.Now
 
 // This version evalautes DateTime.Now every time you call it with a `unit` argument.
-let getCurrentDateTime2 () = DateTime.Now  
+let getCurrentDateTime2 () = DateTime.Now
 
 // How to call the function:
 let startTime = getCurrentDateTime2()
@@ -501,7 +501,7 @@ In C#, if a method has an `out` parameter (e.g. [`DateTime.TryParse`](https://le
 let (success, outParsedDateTime) = System.DateTime.TryParse("2001/02/06")
 ```
 
-See [Tuples (MS Learn)](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/tuples) for learn more.
+See [Tuples (MS Learn)](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/tuples) to learn more.
 
 <div id="data-types-records"></div>
 
@@ -876,20 +876,30 @@ match "yennefer@aretuza.org" with // output: "Email: yennefer@aretuza.org"
 ## Partial active patterns
 
 *Partial active patterns* share the syntax of parameterized patterns, but their active recognizers accept only one argument.
-A *Partial active pattern* must return an `Option<'T>`.
 
-```fsharp
-let (|DivisibleBy|_|) by n =
-    if n % by = 0
-    then Some DivisibleBy
-    else None
+A partial active pattern must return an `Option<'T>` or, as of [F# 9](https://learn.microsoft.com/en-us/dotnet/fsharp/whats-new/fsharp-9#partial-active-patterns-can-return-bool-instead-of-unit-option), a `bool`.
 
-let fizzBuzz = function
-    | DivisibleBy 3 & DivisibleBy 5 -> "FizzBuzz"
-    | DivisibleBy 3 -> "Fizz"
-    | DivisibleBy 5 -> "Buzz"
-    | i -> string i
-```
+- `Option<T>`
+    ```fsharp
+    let (|DivisibleBy|_|) by n =
+        if n % by = 0
+        then Some DivisibleBy
+        else None
+
+    let fizzBuzz = function
+        | DivisibleBy 3 & DivisibleBy 5 -> "FizzBuzz"
+        | DivisibleBy 3 -> "Fizz"
+        | DivisibleBy 5 -> "Buzz"
+        | i -> string i
+    ```
+
+- `bool`
+    ```fsharp
+    let (|CaseInsensitive|_|) (pattern: string) (value: string) =
+        String.Equals(value, pattern, StringComparison.OrdinalIgnoreCase)
+    ```
+
+See [Active Patterns (MS Learn)](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/active-patterns]) to learn more.
 
 <div id="asynchronous-programming"></div>
 

--- a/docs/fsharp-cheatsheet.md
+++ b/docs/fsharp-cheatsheet.md
@@ -219,7 +219,7 @@ let getCurrentDateTime = DateTime.Now
 let getCurrentDateTime2 () = DateTime.Now
 
 // How to call the function:
-let startTime = getCurrentDateTime2()
+let startTime = getCurrentDateTime2 ()
 ```
 
 <div id="functions-signatures"></div>

--- a/docs/fsharp-cheatsheet.md
+++ b/docs/fsharp-cheatsheet.md
@@ -899,7 +899,7 @@ A partial active pattern must return an `Option<'T>` or, as of [F# 9](https://le
         String.Equals(value, pattern, StringComparison.OrdinalIgnoreCase)
     ```
 
-See [Active Patterns (MS Learn)](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/active-patterns]) to learn more.
+See [Active Patterns (MS Learn)](https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/active-patterns) to learn more.
 
 <div id="asynchronous-programming"></div>
 

--- a/docs/template.html
+++ b/docs/template.html
@@ -15,7 +15,7 @@
             <h1>F# Cheatsheet</h1>
 
             <p>
-                This cheatsheet aims to succinctly cover the most important aspects of F# 8.0.
+                This cheatsheet aims to succinctly cover the most important aspects of F# 10.0.
             </p>
 
             <p>


### PR DESCRIPTION
Summary:

- Adds F# 9's new ability for partial active patterns to return `bool`s
- Updates an F# 8 reference near the top to F# 10 (so the document does not appear out of date)
- Fixes a small typo

Happy to make any tweaks necessary, or for others to. Just trying to keep this great resource a bit more up to date.